### PR TITLE
Add code proving arrays are reference types

### DIFF
--- a/section-2/lecture-2.17/play.js
+++ b/section-2/lecture-2.17/play.js
@@ -1,0 +1,23 @@
+const person = {
+  name: "Bobby",
+  age: 58,
+  greeting() {
+    console.log("Hi, I am " + this.name + ".");
+  }
+}
+
+const hobbies = ["Sports", "Cooking"];
+
+// for (let hobby of hobbies) {
+//   console.log(hobby);
+// }
+
+// console.log(hobbies.map(hobby => "Hobby: " + hobby));
+
+// console.log(hobbies);
+
+// Prove that arrays are a reference type:
+
+hobbies.push("Programming");
+
+console.log(hobbies);


### PR DESCRIPTION
Lecture 2-17 focuses on arrays, objects and reference types. The code changed in this iteration demonstrates the fact that an array is a reference type, not a primitive value. This is because in the case of objects or arrays, even though they might be constants, their content may be altered. It is not the array, which merely stores a memory address is changed. This cannot change. But the contents stored at that memory address can be changed.

This code should now be merged into the **master** branch.