### PR TITLE
Demonstrate arrays as a reference type

### DIFF
--- a/section-2/lecture-2.18/play.js
+++ b/section-2/lecture-2.18/play.js
@@ -1,0 +1,25 @@
+const person = {
+  name: "Bobby",
+  age: 58,
+  greet() {
+    console.log("Hi, I am " + this.name + ".");
+  }
+};
+
+person.greet();
+
+const hobbies = ["Sports", "Cooking"];
+
+// for (let hobby of hobbies) {
+//   console.log(hobby);
+// }
+
+// console.log(hobbies.map(hobby => "Hobby: " + hobby));
+
+// Demonstrate that arrays are a reference type:
+
+console.log(hobbies);
+
+hobbies.push("Programming");
+
+console.log(hobbies);


### PR DESCRIPTION
**Lecture 2-18** demonstrates that arrays are a reference type. As a reference type even though the array might be defined as a `const`, its contents can still be altered. This is because as a reference type, arrays store a location in volatile memory in which data is to be temporarily stored.

When changes are introduced, **the memory address for the data is not altered; only the data at that address is altered.**

This code is ready to be merged into the **master** branch.